### PR TITLE
replace depricated function

### DIFF
--- a/pytorch_grad_cam/activations_and_gradients.py
+++ b/pytorch_grad_cam/activations_and_gradients.py
@@ -8,7 +8,7 @@ class ActivationsAndGradients:
         self.activations = []
 
         target_layer.register_forward_hook(self.save_activation)
-        target_layer.register_backward_hook(self.save_gradient)
+        target_layer.register_full_backward_hook(self.save_gradient)
 
     def save_activation(self, module, input, output):
         self.activations.append(output)
@@ -19,5 +19,5 @@ class ActivationsAndGradients:
 
     def __call__(self, x):
         self.gradients = []
-        self.activations = []        
+        self.activations = []
         return self.model(x)


### PR DESCRIPTION
replaces the depricated [`register_backward_hook`](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_backward_hook) with [`register_full_backward_hook`](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_full_backward_hook), fixing the following UserWarning:
```
.../torch/nn/modules/module.py:795: UserWarning: Using a non-full backward hook when the forward contains multiple autograd Nodes is deprecated and will be removed in future versions. This hook will be missing some grad_input. Please use register_full_backward_hook to get the documented behavior.
  warnings.warn("Using a non-full backward hook when the forward contains multiple autograd Nodes "
```
This warning results in case of `ResNets`, where an entire `BasicBlock` is considered as the target layer. Unlike `VGG` or `DenseNet`, where only a single layer is considered.

> ___Note:___ The behavior of `register_full_backward_hook` stays the same as that of `register_backward_hook` when there is only a single layer.