### PR TITLE
Optional conversion to RGB and custom colormap in show_cam_on_image

### DIFF
--- a/pytorch_grad_cam/utils/image.py
+++ b/pytorch_grad_cam/utils/image.py
@@ -28,8 +28,10 @@ def deprocess_image(img):
     return np.uint8(img * 255)
 
 
-def show_cam_on_image(img: np.ndarray, mask: np.ndarray) -> np.ndarray:
+def show_cam_on_image(img: np.ndarray, mask: np.ndarray, return_rgb: bool = False) -> np.ndarray:
     heatmap = cv2.applyColorMap(np.uint8(255 * mask), cv2.COLORMAP_JET)
+    if return_rgb:
+        heatmap = cv2.cvtColor(heatmap, cv2.COLOR_BGR2RGB)
     heatmap = np.float32(heatmap) / 255
     cam = heatmap + np.float32(img)
     cam = cam / np.max(cam)

--- a/pytorch_grad_cam/utils/image.py
+++ b/pytorch_grad_cam/utils/image.py
@@ -28,9 +28,18 @@ def deprocess_image(img):
     return np.uint8(img * 255)
 
 
-def show_cam_on_image(img: np.ndarray, mask: np.ndarray, return_rgb: bool = False) -> np.ndarray:
-    heatmap = cv2.applyColorMap(np.uint8(255 * mask), cv2.COLORMAP_JET)
-    if return_rgb:
+def show_cam_on_image(img: np.ndarray, mask: np.ndarray, use_rgb: bool = False, colormap: int = cv2.COLORMAP_JET) -> np.ndarray:
+    """ This function overlays the cam mask on the image as an heatmap.
+    By default the heatmap is in BGR format.
+
+    :param img: The base image in RGB or BGR format.
+    :param mask: The cam mask.
+    :param use_rgb: Whether to use an RGB or BGR heatmap, this should be set to True if 'img' is in RGB format.
+    :param colormap: The OpenCV colormap to be used.
+    :returns: The default image with the cam overlay.
+    """
+    heatmap = cv2.applyColorMap(np.uint8(255 * mask), colormap)
+    if use_rgb:
         heatmap = cv2.cvtColor(heatmap, cv2.COLOR_BGR2RGB)
     heatmap = np.float32(heatmap) / 255
     cam = heatmap + np.float32(img)


### PR DESCRIPTION
https://github.com/jacobgil/pytorch-grad-cam/blob/278c9cd92f3436bc0c9cde7cf0d98f9ff12ed415/pytorch_grad_cam/utils/image.py#L31

# Changes

This PR modifies the referenced function adding the  following functionalities:
* Option to convert the heat-map to RGB format.
* Option to pass a specific OpenCV colormap to be used.

# Motivation

The referenced function, as of now, builds an OpenCV colormap and uses it as is. Since OpenCV uses BGR format as default, instead of RGB, this can be misleading; for example if the user handles images with a library different than OpenCV itself.
Moreover, with the JET colormap, results seem switched up, where the high importance regions are colored as low importance ones and viceversa. 

This PR addresses these problems by adding the two options mentioned in the previous section. In this way the user can easily integrate the provided utility function with its own code, whether uses another image processing library or wants to color the images differently.

The changes are fully backward compatible since the defaults are compliant with the current behavior, hence nothing breaks for current users.

Hope this is helpful!