### PR TITLE
BUG-137: Add install_requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,8 @@
 
 ⭐ Full support for batches of images in all methods.
 
-
 ![visualization](https://github.com/jacobgil/jacobgil.github.io/blob/master/assets/cam_dog.gif?raw=true
 )
-
-
 
 | Method   | What it does |
 |----------|--------------|

--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,11 @@ setuptools.setup(
     ],
     packages=setuptools.find_packages(),
     python_requires='>=3.6',
+    install_requires=[
+        'opencv-python>=4.5'
+        'torch>=1.4',
+        'torchvision>=0.5',
+        'ttach>=0.0.3',
+        'tqdm>=4.42'
+    ]
 )


### PR DESCRIPTION
Add install_requires to setup.py for #137 

Checked running with latest versions of each library as well as a version
from beginning of 2020 for each library. Seems to be okay.

Note: opencv python dependency has missing system dependency on
a clean python:3.8.5 image from DockerHub. Followed instructions
specified in the linked SO post. Unsure if you want me to mention
these instructions in the README.
https://stackoverflow.com/a/68666500/5094465