### PR TITLE
Update base_cam.py

### DIFF
--- a/pytorch_grad_cam/base_cam.py
+++ b/pytorch_grad_cam/base_cam.py
@@ -121,6 +121,7 @@ class BaseCAM:
                                      layer_activations,
                                      layer_grads,
                                      eigen_smooth)
+            cam[cam<0]=0 # works like mute the min-max scale in the function of scale_cam_image
             scaled = self.scale_cam_image(cam, target_size)
             cam_per_target_layer.append(scaled[:, None, :])
 


### PR DESCRIPTION
In Gram-CAM, Undo the Min-Max scale on the CAM before ReLU by adding just one single line in the compute_cam_per_layer instead of big change in the scale_cam_image and aggregate_multi_layers.