### PR TITLE
Use forward hook instead of backward hook to avoid error

### DIFF
--- a/pytorch_grad_cam/activations_and_gradients.py
+++ b/pytorch_grad_cam/activations_and_gradients.py
@@ -23,6 +23,9 @@ class ActivationsAndGradients:
         self.activations.append(activation.cpu().detach())
 
     def save_gradient(self, module, input, output):
+        if not output.requires_grad:
+            # You can only register hooks on tensor requires grad.
+            return
         # Gradients are computed in reverse order
         def _store_grad(grad):
             if self.reshape_transform is not None:


### PR DESCRIPTION
Hello, I'm the developer of [mmclassification](https://github.com/open-mmlab/mmclassification), and we want to provide a tool to visualize the CAM graph with your library.
However, I found a problem that may cause
```
RuntimeError: Output 0 of BackwardHookFunctionBackward is a view and is being modified in place.
```
The problem is because that in-place operations are not compatible with backward hooks, which refers to https://github.com/pytorch/pytorch/issues/61519.
And in this PR, I fixed this problem according to https://github.com/pytorch/pytorch/issues/61519#issuecomment-883524237.
Please check it.