### PR TITLE
README.md: fix argument in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ cam = GradCAM(model=model, target_layers=target_layers, use_cuda=args.use_cuda)
 targets = [e.g ClassifierOutputTarget(281)]
 
 # You can also pass aug_smooth=True and eigen_smooth=True, to apply smoothing.
-grayscale_cam = cam(input_tensor=input_tensor, target_category=target_category)
+grayscale_cam = cam(input_tensor=input_tensor, targets=targets)
 
 # In this example grayscale_cam has only one image in the batch:
 grayscale_cam = grayscale_cam[0, :]


### PR DESCRIPTION
the argument `target_categories` should just be `targets` in the example code I think (the latter works with version 1.3.7)