### PR TITLE
Fixed argument for Example usage

### DIFF
--- a/usage_examples/vit_example.py
+++ b/usage_examples/vit_example.py
@@ -62,7 +62,7 @@ def reshape_transform(tensor, height=14, width=14):
 
 
 if __name__ == '__main__':
-    """ python vit_gradcam.py -image-path <path_to_image>
+    """ python vit_gradcam.py --image-path <path_to_image>
     Example usage of using cam-methods on a VIT network.
 
     """


### PR DESCRIPTION
To start the VT-Example the Image-Path has to start with two dashes