### PR TITLE
Add GradCAM elementwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,18 @@
 ![visualization](https://github.com/jacobgil/jacobgil.github.io/blob/master/assets/cam_dog.gif?raw=true
 )
 
-| Method   | What it does |
-|----------|--------------|
-| GradCAM  | Weight the 2D activations by the average gradient |
-| GradCAM++  | Like GradCAM but uses second order gradients |
-| XGradCAM  | Like GradCAM but scale the gradients by the normalized activations |
-| AblationCAM  | Zero out activations and measure how the output drops (this repository includes a fast batched implementation) |
-| ScoreCAM  | Perbutate the image by the scaled activations and measure how the output drops |
-| EigenCAM  | Takes the first principle component of the 2D Activations (no class discrimination, but seems to give great results)|
-| EigenGradCAM  | Like EigenCAM but with class discrimination: First principle component of Activations*Grad. Looks like GradCAM, but cleaner|
-| LayerCAM  | Spatially weight the activations by positive gradients. Works better especially in lower layers |
-| FullGrad  | Computes the gradients of the biases from all over the network, and then sums them |
+| Method             | What it does                                                                                                                |
+|--------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| GradCAM            | Weight the 2D activations by the average gradient                                                                           |
+| GradCAM++          | Like GradCAM but uses second order gradients                                                                                |
+| GradCAMElementWise | Like GradCAM but getting the maximum instead of average gradient                                                            |
+| XGradCAM           | Like GradCAM but scale the gradients by the normalized activations                                                          |
+| AblationCAM        | Zero out activations and measure how the output drops (this repository includes a fast batched implementation)              |
+| ScoreCAM           | Perbutate the image by the scaled activations and measure how the output drops                                              |
+| EigenCAM           | Takes the first principle component of the 2D Activations (no class discrimination, but seems to give great results)        |
+| EigenGradCAM       | Like EigenCAM but with class discrimination: First principle component of Activations*Grad. Looks like GradCAM, but cleaner |
+| LayerCAM           | Spatially weight the activations by positive gradients. Works better especially in lower layers                             |
+| FullGrad           | Computes the gradients of the biases from all over the network, and then sums them                                          |
 
 ## Visual Examples
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 |--------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | GradCAM            | Weight the 2D activations by the average gradient                                                                           |
 | GradCAM++          | Like GradCAM but uses second order gradients                                                                                |
-| GradCAMElementWise | Like GradCAM but getting the maximum instead of average gradient                                                            |
+| GradCAMElementWise | Like GradCAM but element-wise multiply the activations with the gradients                                                   |
 | XGradCAM           | Like GradCAM but scale the gradients by the normalized activations                                                          |
 | AblationCAM        | Zero out activations and measure how the output drops (this repository includes a fast batched implementation)              |
 | ScoreCAM           | Perbutate the image by the scaled activations and measure how the output drops                                              |

--- a/pytorch_grad_cam/__init__.py
+++ b/pytorch_grad_cam/__init__.py
@@ -1,4 +1,5 @@
 from pytorch_grad_cam.grad_cam import GradCAM
+from pytorch_grad_cam.grad_cam_elementwise import GradCAMElementWise
 from pytorch_grad_cam.ablation_layer import AblationLayer, AblationLayerVit, AblationLayerFasterRCNN
 from pytorch_grad_cam.ablation_cam import AblationCAM
 from pytorch_grad_cam.xgrad_cam import XGradCAM

--- a/pytorch_grad_cam/grad_cam_elementwise.py
+++ b/pytorch_grad_cam/grad_cam_elementwise.py
@@ -1,0 +1,30 @@
+import numpy as np
+from pytorch_grad_cam.base_cam import BaseCAM
+from pytorch_grad_cam.utils.svd_on_activations import get_2d_projection
+
+class GradCAMElementWise(BaseCAM):
+    def __init__(self, model, target_layers, use_cuda=False,
+                 reshape_transform=None):
+        super(
+            GradCAMElementWise,
+            self).__init__(
+            model,
+            target_layers,
+            use_cuda,
+            reshape_transform)
+
+    def get_cam_image(self,
+                      input_tensor,
+                      target_layer,
+                      target_category,
+                      activations,
+                      grads,
+                      eigen_smooth):
+        elementwise_activations = np.maximum(grads * activations, 0)
+
+
+        if eigen_smooth:
+            cam = get_2d_projection(elementwise_activations)
+        else:
+            cam = elementwise_activations.sum(axis=1)
+        return cam


### PR DESCRIPTION
Added GradCAM ElementWise implementation as a proposed by this publication: https://www.aaai.org/AAAI21Papers/AAAI-8236.PillaiV.pdf


When tested on a ResNet50 network, and changing the last avg pooling layer for a max pooling layer, GradCAM element wise produces more accurate localizations of object activations (measured by counting overlapping pixels between an object bounding box and the cam activation)

