### PR TITLE
fix AblationLayerVit for Swin models

### DIFF
--- a/pytorch_grad_cam/ablation_layer.py
+++ b/pytorch_grad_cam/ablation_layer.py
@@ -80,7 +80,7 @@ class AblationLayerVit(AblationLayer):
 
     def __call__(self, x):
         output = self.activations
-        output = output.transpose(1, 2)
+        output = output.transpose(1, len(output.shape) - 1)
         for i in range(output.size(0)):
 
             # Commonly the minimum activation will be 0,
@@ -95,7 +95,7 @@ class AblationLayerVit(AblationLayer):
                 output[i, self.indices[i], :] = torch.min(
                     output) - ABLATION_VALUE
 
-        output = output.transpose(2, 1)
+        output = output.transpose(len(output.shape) - 1, 1)
 
         return output
 
@@ -103,7 +103,8 @@ class AblationLayerVit(AblationLayer):
         """ This creates the next batch of activations from the layer.
             Just take corresponding batch member from activations, and repeat it num_channels_to_ablate times.
         """
-        self.activations = activations[input_batch_index, :, :].clone().unsqueeze(0).repeat(num_channels_to_ablate, 1, 1)
+        repeat_params = [num_channels_to_ablate] + len(activations.shape[:-1]) * [1]
+        self.activations = activations[input_batch_index, :, :].clone().unsqueeze(0).repeat(*repeat_params)
 
 
 


### PR DESCRIPTION
AblationLayerVit only works with 3-dimensional activations (e.g. (1,50,768)). This fix makes it work with 4-dimensional inputs such as that of the Swin-T model from Torchvision, as it returns activations of shape (1,7,7,768).