### PR TITLE
Add back Grad-CAM Elementwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The aim is also to serve as a benchmark of algorithms and metrics for research o
 |--------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | GradCAM            | Weight the 2D activations by the average gradient                                                                           |
 | HiResCAM           | Like GradCAM but element-wise multiply the activations with the gradients; [provably guaranteed faithfulness](https://arxiv.org/abs/2011.08891) for certain models |
+| GradCAMElementWise | Like GradCAM but element-wise multiply the activations with the gradients then apply a ReLU operation before summing        |
 | GradCAM++          | Like GradCAM but uses second order gradients                                                                                |
 | XGradCAM           | Like GradCAM but scale the gradients by the normalized activations                                                          |
 | AblationCAM        | Zero out activations and measure how the output drops (this repository includes a fast batched implementation)              |

--- a/cam.py
+++ b/cam.py
@@ -12,7 +12,8 @@ from pytorch_grad_cam import GradCAM, \
     EigenCAM, \
     EigenGradCAM, \
     LayerCAM, \
-    FullGrad
+    FullGrad, \
+    GradCAMElementWise
     
 
 from pytorch_grad_cam import GuidedBackpropReLUModel
@@ -75,7 +76,8 @@ if __name__ == '__main__':
          "eigencam": EigenCAM,
          "eigengradcam": EigenGradCAM,
          "layercam": LayerCAM,
-         "fullgrad": FullGrad}
+         "fullgrad": FullGrad,
+         "gradcamelementwise": GradCAMElementWise}
 
     model = models.resnet50(pretrained=True)
 

--- a/pytorch_grad_cam/__init__.py
+++ b/pytorch_grad_cam/__init__.py
@@ -1,5 +1,6 @@
 from pytorch_grad_cam.grad_cam import GradCAM
 from pytorch_grad_cam.hirescam import HiResCAM
+from pytorch_grad_cam.grad_cam_elementwise import GradCAMElementWise
 from pytorch_grad_cam.ablation_layer import AblationLayer, AblationLayerVit, AblationLayerFasterRCNN
 from pytorch_grad_cam.ablation_cam import AblationCAM
 from pytorch_grad_cam.xgrad_cam import XGradCAM

--- a/pytorch_grad_cam/grad_cam_elementwise.py
+++ b/pytorch_grad_cam/grad_cam_elementwise.py
@@ -1,0 +1,30 @@
+import numpy as np
+from pytorch_grad_cam.base_cam import BaseCAM
+from pytorch_grad_cam.utils.svd_on_activations import get_2d_projection
+
+class GradCAMElementWise(BaseCAM):
+    def __init__(self, model, target_layers, use_cuda=False,
+                 reshape_transform=None):
+        super(
+            GradCAMElementWise,
+            self).__init__(
+            model,
+            target_layers,
+            use_cuda,
+            reshape_transform)
+
+    def get_cam_image(self,
+                      input_tensor,
+                      target_layer,
+                      target_category,
+                      activations,
+                      grads,
+                      eigen_smooth):
+        elementwise_activations = np.maximum(grads * activations, 0)
+
+
+        if eigen_smooth:
+            cam = get_2d_projection(elementwise_activations)
+        else:
+            cam = elementwise_activations.sum(axis=1)
+        return cam


### PR DESCRIPTION
After discussion with the authors of Grad-CAM Elementwise, it appears their method was developed in parallel to HiResCAM. Thus, this PR adds back in the Grad-CAM Elementwise method, which differs from HiResCAM in the application of an additional ReLU.