### PR TITLE
Retain model outputs during CAM inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ grayscale_cam = cam(input_tensor=input_tensor, targets=targets)
 # In this example grayscale_cam has only one image in the batch:
 grayscale_cam = grayscale_cam[0, :]
 visualization = show_cam_on_image(rgb_img, grayscale_cam, use_rgb=True)
+
+# You can also get the model outputs without having to re-inference
+model_outputs = cam.outputs
 ```
 
 ----------

--- a/pytorch_grad_cam/base_cam.py
+++ b/pytorch_grad_cam/base_cam.py
@@ -71,7 +71,8 @@ class BaseCAM:
             input_tensor = torch.autograd.Variable(input_tensor,
                                                    requires_grad=True)
 
-        outputs = self.activations_and_grads(input_tensor)
+        self.outputs = outputs = self.activations_and_grads(input_tensor)
+
         if targets is None:
             target_categories = np.argmax(outputs.cpu().data.numpy(), axis=-1)
             targets = [ClassifierOutputTarget(


### PR DESCRIPTION
Implements the suggestion in this issue:
https://github.com/jacobgil/pytorch-grad-cam/issues/392

Also added 1-liner to README with example