### PR TITLE
fix: build wheel by requirements.txt not pack

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
Thanks for the convenient and amazing collection for all the grad-cam based method.
You just published the 1.4.7 version in June, 15, 2023. As for the changing in setuptool, people cannot install the from `pip install grad-cam` right now. 

It will come into a build failure in wheel like this

1.  on macos
<img width="1419" alt="企业微信截图_65e1c361-45b8-4e57-af43-5d93bb562c6f" src="https://github.com/jacobgil/pytorch-grad-cam/assets/42485228/8805a4f3-79bf-4db2-a1d8-1c0cd92a1a39">
2. on linux


![企业微信截图_6f68287d-817c-4fee-89e9-5f5bf6b08976](https://github.com/jacobgil/pytorch-grad-cam/assets/42485228/cf406d93-f465-4934-9679-3a1cea0ac886)



the setup.py need requirement.txt as usual, but the setuptools changing in recent half years make it not pack requirement.txt anymore.
This PR is a fast and minial fixing, just adding a config file reading by wheel builder to include requirements.txt mannully
If you need I can make a PR to turn the whole package into a modern pakcage tool like poetry with full tests.

Reference:
1. include-requirements-txt-file-in-python-wheel: https://stackoverflow.com/questions/38533669/include-requirements-txt-file-in-python-wheel
2. setuptools not support the MANIFEST.in setting yet: https://github.com/pypa/setuptools/issues/3341
3. poetry setting: https://python-poetry.org/docs/pyproject/#include-and-exclude
