### PR TITLE
add required gad when init basecam class

### DIFF
--- a/pytorch_grad_cam/base_cam.py
+++ b/pytorch_grad_cam/base_cam.py
@@ -16,6 +16,8 @@ class BaseCAM:
                  reshape_transform: Callable = None,
                  compute_input_gradient: bool = False,
                  uses_gradients: bool = True) -> None:
+        for params in model.parameters():
+            params.requires_grad = True
         self.model = model.eval()
         self.target_layers = target_layers
         self.cuda = use_cuda


### PR DESCRIPTION
I encountered the error `AxisError: axis 2 is out of bounds for array of dimension 0`, which was caused by the value of `grads`(the input of the function `get_cam_weights` in every CAM class) being None. This occurred because no gradient was able to compute, due to the fact that model.required_grad was set to false during the training process by the user.