### PR TITLE
mps support

### DIFF
--- a/cam.py
+++ b/cam.py
@@ -4,6 +4,7 @@ import cv2
 import numpy as np
 import torch
 from torchvision import models
+from torchvision.models import ResNet50_Weights
 from pytorch_grad_cam import (
     GradCAM, HiResCAM, ScoreCAM, GradCAMPlusPlus,
     AblationCAM, XGradCAM, EigenCAM, EigenGradCAM,
@@ -18,8 +19,8 @@ from pytorch_grad_cam.utils.model_targets import ClassifierOutputTarget
 
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--use-cuda', action='store_true', default=False,
-                        help='Use NVIDIA GPU acceleration')
+    parser.add_argument('--device', type=str, default=None,
+                        help='Torch device to use')
     parser.add_argument(
         '--image-path',
         type=str,
@@ -44,9 +45,9 @@ def get_args():
     parser.add_argument('--output-dir', type=str, default='output',
                         help='Output directory to save the images')
     args = parser.parse_args()
-    args.use_cuda = args.use_cuda and torch.cuda.is_available()
-    if args.use_cuda:
-        print('Using GPU for acceleration')
+    
+    if args.device:
+        print(f'Using device "{args.device}" for acceleration')
     else:
         print('Using CPU for computation')
 
@@ -76,7 +77,7 @@ if __name__ == '__main__':
         "gradcamelementwise": GradCAMElementWise
     }
 
-    model = models.resnet50(pretrained=True)
+    model = models.resnet50(weights=ResNet50_Weights.DEFAULT).to(args.device).eval()
 
     # Choose the target layer you want to compute the visualization for.
     # Usually this will be the last convolutional layer in the model.
@@ -97,7 +98,7 @@ if __name__ == '__main__':
     rgb_img = np.float32(rgb_img) / 255
     input_tensor = preprocess_image(rgb_img,
                                     mean=[0.485, 0.456, 0.406],
-                                    std=[0.229, 0.224, 0.225])
+                                    std=[0.229, 0.224, 0.225]).to(args.device)
 
     # We have to specify the target we want to generate
     # the Class Activation Maps for.
@@ -111,7 +112,7 @@ if __name__ == '__main__':
     cam_algorithm = methods[args.method]
     with cam_algorithm(model=model,
                        target_layers=target_layers,
-                       use_cuda=args.use_cuda) as cam:
+                       device=args.device) as cam:
 
 
         # AblationCAM and ScoreCAM have batched implementations.
@@ -127,7 +128,7 @@ if __name__ == '__main__':
         cam_image = show_cam_on_image(rgb_img, grayscale_cam, use_rgb=True)
         cam_image = cv2.cvtColor(cam_image, cv2.COLOR_RGB2BGR)
 
-    gb_model = GuidedBackpropReLUModel(model=model, use_cuda=args.use_cuda)
+    gb_model = GuidedBackpropReLUModel(model=model, device=args.device)
     gb = gb_model(input_tensor, target_category=None)
 
     cam_mask = cv2.merge([grayscale_cam, grayscale_cam, grayscale_cam])

--- a/pytorch_grad_cam/ablation_cam.py
+++ b/pytorch_grad_cam/ablation_cam.py
@@ -28,7 +28,7 @@ class AblationCAM(BaseCAM):
     def __init__(self,
                  model: torch.nn.Module,
                  target_layers: List[torch.nn.Module],
-                 use_cuda: bool = False,
+                 device: torch.device = None,
                  reshape_transform: Callable = None,
                  ablation_layer: torch.nn.Module = AblationLayer(),
                  batch_size: int = 32,
@@ -36,7 +36,7 @@ class AblationCAM(BaseCAM):
 
         super(AblationCAM, self).__init__(model,
                                           target_layers,
-                                          use_cuda,
+                                          device,
                                           reshape_transform,
                                           uses_gradients=False)
         self.batch_size = batch_size

--- a/pytorch_grad_cam/ablation_cam_multilayer.py
+++ b/pytorch_grad_cam/ablation_cam_multilayer.py
@@ -57,9 +57,9 @@ def replace_layer_recursive(model, old_layer, new_layer):
 
 
 class AblationCAM(BaseCAM):
-    def __init__(self, model, target_layers, use_cuda=False,
+    def __init__(self, model, target_layers, device=None,
                  reshape_transform=None):
-        super(AblationCAM, self).__init__(model, target_layers, use_cuda,
+        super(AblationCAM, self).__init__(model, target_layers, device,
                                           reshape_transform)
 
         if len(target_layers) > 1:

--- a/pytorch_grad_cam/base_cam.py
+++ b/pytorch_grad_cam/base_cam.py
@@ -12,16 +12,17 @@ class BaseCAM:
     def __init__(self,
                  model: torch.nn.Module,
                  target_layers: List[torch.nn.Module],
-                 use_cuda: bool = False,
+                 device: torch.device = None,
                  reshape_transform: Callable = None,
                  compute_input_gradient: bool = False,
                  uses_gradients: bool = True,
                  tta_transforms: Optional[tta.Compose] = None) -> None:
         self.model = model.eval()
         self.target_layers = target_layers
-        self.cuda = use_cuda
-        if self.cuda:
-            self.model = model.cuda()
+        self.device = device
+        if self.device is not None:
+            self.model.to(self.device)
+
         self.reshape_transform = reshape_transform
         self.compute_input_gradient = compute_input_gradient
         self.uses_gradients = uses_gradients
@@ -75,8 +76,8 @@ class BaseCAM:
                 targets: List[torch.nn.Module],
                 eigen_smooth: bool = False) -> np.ndarray:
 
-        if self.cuda:
-            input_tensor = input_tensor.cuda()
+        if self.device is not None:
+            input_tensor = input_tensor.to(self.device)
 
         if self.compute_input_gradient:
             input_tensor = torch.autograd.Variable(input_tensor,

--- a/pytorch_grad_cam/eigen_cam.py
+++ b/pytorch_grad_cam/eigen_cam.py
@@ -5,11 +5,11 @@ from pytorch_grad_cam.utils.svd_on_activations import get_2d_projection
 
 
 class EigenCAM(BaseCAM):
-    def __init__(self, model, target_layers, use_cuda=False,
+    def __init__(self, model, target_layers, device=None,
                  reshape_transform=None):
         super(EigenCAM, self).__init__(model,
                                        target_layers,
-                                       use_cuda,
+                                       device,
                                        reshape_transform,
                                        uses_gradients=False)
 

--- a/pytorch_grad_cam/eigen_grad_cam.py
+++ b/pytorch_grad_cam/eigen_grad_cam.py
@@ -6,9 +6,9 @@ from pytorch_grad_cam.utils.svd_on_activations import get_2d_projection
 
 
 class EigenGradCAM(BaseCAM):
-    def __init__(self, model, target_layers, use_cuda=False,
+    def __init__(self, model, target_layers, device=None,
                  reshape_transform=None):
-        super(EigenGradCAM, self).__init__(model, target_layers, use_cuda,
+        super(EigenGradCAM, self).__init__(model, target_layers, device,
                                            reshape_transform)
 
     def get_cam_image(self,

--- a/pytorch_grad_cam/fullgrad_cam.py
+++ b/pytorch_grad_cam/fullgrad_cam.py
@@ -9,7 +9,7 @@ from pytorch_grad_cam.utils.image import scale_accross_batch_and_channels, scale
 
 
 class FullGrad(BaseCAM):
-    def __init__(self, model, target_layers, use_cuda=False,
+    def __init__(self, model, target_layers, device=None,
                  reshape_transform=None):
         if len(target_layers) > 0:
             print(
@@ -27,7 +27,7 @@ class FullGrad(BaseCAM):
             self).__init__(
             model,
             target_layers,
-            use_cuda,
+            device,
             reshape_transform,
             compute_input_gradient=True)
         self.bias_data = [self.get_bias_data(

--- a/pytorch_grad_cam/grad_cam.py
+++ b/pytorch_grad_cam/grad_cam.py
@@ -3,14 +3,14 @@ from pytorch_grad_cam.base_cam import BaseCAM
 
 
 class GradCAM(BaseCAM):
-    def __init__(self, model, target_layers, use_cuda=False,
+    def __init__(self, model, target_layers, device=None,
                  reshape_transform=None):
         super(
             GradCAM,
             self).__init__(
             model,
             target_layers,
-            use_cuda,
+            device,
             reshape_transform)
 
     def get_cam_weights(self,

--- a/pytorch_grad_cam/grad_cam_elementwise.py
+++ b/pytorch_grad_cam/grad_cam_elementwise.py
@@ -4,14 +4,14 @@ from pytorch_grad_cam.utils.svd_on_activations import get_2d_projection
 
 
 class GradCAMElementWise(BaseCAM):
-    def __init__(self, model, target_layers, use_cuda=False,
+    def __init__(self, model, target_layers, device=None,
                  reshape_transform=None):
         super(
             GradCAMElementWise,
             self).__init__(
             model,
             target_layers,
-            use_cuda,
+            device,
             reshape_transform)
 
     def get_cam_image(self,

--- a/pytorch_grad_cam/grad_cam_plusplus.py
+++ b/pytorch_grad_cam/grad_cam_plusplus.py
@@ -5,9 +5,9 @@ from pytorch_grad_cam.base_cam import BaseCAM
 
 
 class GradCAMPlusPlus(BaseCAM):
-    def __init__(self, model, target_layers, use_cuda=False,
+    def __init__(self, model, target_layers, device=None,
                  reshape_transform=None):
-        super(GradCAMPlusPlus, self).__init__(model, target_layers, use_cuda,
+        super(GradCAMPlusPlus, self).__init__(model, target_layers, device,
                                               reshape_transform)
 
     def get_cam_weights(self,

--- a/pytorch_grad_cam/guided_backprop.py
+++ b/pytorch_grad_cam/guided_backprop.py
@@ -44,12 +44,12 @@ class GuidedBackpropReLUasModule(torch.nn.Module):
 
 
 class GuidedBackpropReLUModel:
-    def __init__(self, model, use_cuda):
+    def __init__(self, model, device):
         self.model = model
         self.model.eval()
-        self.cuda = use_cuda
-        if self.cuda:
-            self.model = self.model.cuda()
+        self.device = device
+        if self.device:
+            self.model = self.model.to(self.device)
 
     def forward(self, input_img):
         return self.model(input_img)
@@ -76,8 +76,8 @@ class GuidedBackpropReLUModel:
                                          torch.nn.ReLU,
                                          GuidedBackpropReLUasModule())
 
-        if self.cuda:
-            input_img = input_img.cuda()
+        if self.device:
+            input_img = input_img.to(self.device)
 
         input_img = input_img.requires_grad_(True)
 

--- a/pytorch_grad_cam/hirescam.py
+++ b/pytorch_grad_cam/hirescam.py
@@ -4,14 +4,14 @@ from pytorch_grad_cam.utils.svd_on_activations import get_2d_projection
 
 
 class HiResCAM(BaseCAM):
-    def __init__(self, model, target_layers, use_cuda=False,
+    def __init__(self, model, target_layers, device=None,
                  reshape_transform=None):
         super(
             HiResCAM,
             self).__init__(
             model,
             target_layers,
-            use_cuda,
+            device,
             reshape_transform)
 
     def get_cam_image(self,

--- a/pytorch_grad_cam/layer_cam.py
+++ b/pytorch_grad_cam/layer_cam.py
@@ -10,14 +10,14 @@ class LayerCAM(BaseCAM):
             self,
             model,
             target_layers,
-            use_cuda=False,
+            device=None,
             reshape_transform=None):
         super(
             LayerCAM,
             self).__init__(
             model,
             target_layers,
-            use_cuda,
+            device,
             reshape_transform)
 
     def get_cam_image(self,

--- a/pytorch_grad_cam/random_cam.py
+++ b/pytorch_grad_cam/random_cam.py
@@ -3,14 +3,14 @@ from pytorch_grad_cam.base_cam import BaseCAM
 
 
 class RandomCAM(BaseCAM):
-    def __init__(self, model, target_layers, use_cuda=False,
+    def __init__(self, model, target_layers, device=None,
                  reshape_transform=None):
         super(
             RandomCAM,
             self).__init__(
             model,
             target_layers,
-            use_cuda,
+            device,
             reshape_transform)
 
     def get_cam_weights(self,

--- a/pytorch_grad_cam/score_cam.py
+++ b/pytorch_grad_cam/score_cam.py
@@ -8,11 +8,11 @@ class ScoreCAM(BaseCAM):
             self,
             model,
             target_layers,
-            use_cuda=False,
+            device=None,
             reshape_transform=None):
         super(ScoreCAM, self).__init__(model,
                                        target_layers,
-                                       use_cuda,
+                                       device,
                                        reshape_transform=reshape_transform,
                                        uses_gradients=False)
 
@@ -26,8 +26,8 @@ class ScoreCAM(BaseCAM):
             upsample = torch.nn.UpsamplingBilinear2d(
                 size=input_tensor.shape[-2:])
             activation_tensor = torch.from_numpy(activations)
-            if self.cuda:
-                activation_tensor = activation_tensor.cuda()
+            if self.device:
+                activation_tensor = activation_tensor.to(self.device)
 
             upsampled = upsample(activation_tensor)
 

--- a/pytorch_grad_cam/utils/model_targets.py
+++ b/pytorch_grad_cam/utils/model_targets.py
@@ -61,6 +61,8 @@ class SemanticSegmentationTarget:
         self.mask = torch.from_numpy(mask)
         if torch.cuda.is_available():
             self.mask = self.mask.cuda()
+        if torch.backends.mps.is_available():
+            self.mask = self.mask.to("mps")
 
     def __call__(self, model_output):
         return (model_output[self.category, :, :] * self.mask).sum()
@@ -86,6 +88,8 @@ class FasterRCNNBoxScoreTarget:
         output = torch.Tensor([0])
         if torch.cuda.is_available():
             output = output.cuda()
+        elif torch.backends.mps.is_available():
+            output = output.to("mps")
 
         if len(model_outputs["boxes"]) == 0:
             return output
@@ -94,6 +98,8 @@ class FasterRCNNBoxScoreTarget:
             box = torch.Tensor(box[None, :])
             if torch.cuda.is_available():
                 box = box.cuda()
+            elif torch.backends.mps.is_available():
+                box = box.to("mps")
 
             ious = torchvision.ops.box_iou(box, model_outputs["boxes"])
             index = ious.argmax()

--- a/pytorch_grad_cam/xgrad_cam.py
+++ b/pytorch_grad_cam/xgrad_cam.py
@@ -7,14 +7,14 @@ class XGradCAM(BaseCAM):
             self,
             model,
             target_layers,
-            use_cuda=False,
+            device=None,
             reshape_transform=None):
         super(
             XGradCAM,
             self).__init__(
             model,
             target_layers,
-            use_cuda,
+            device,
             reshape_transform)
 
     def get_cam_weights(self,

--- a/tests/test_context_release.py
+++ b/tests/test_context_release.py
@@ -58,7 +58,7 @@ def test_memory_usage_in_loop(numpy_image, batch_size, width, height,
     for i in range(100):
         with cam_method(model=model,
                         target_layers=target_layers,
-                        use_cuda=False) as cam:
+                        device=None) as cam:
             grayscale_cam = cam(input_tensor=input_tensor,
                                 targets=targets,
                                 aug_smooth=aug_smooth,

--- a/tests/test_one_channel.py
+++ b/tests/test_one_channel.py
@@ -43,7 +43,7 @@ def test_memory_usage_in_loop(numpy_image, cam_method):
     targets = None
     with cam_method(model=model,
                     target_layers=target_layers,
-                    use_cuda=False) as cam:
+                    device=None) as cam:
         grayscale_cam = cam(input_tensor=input_tensor,
                             targets=targets)
         print(grayscale_cam.shape)

--- a/tests/test_run_all_models.py
+++ b/tests/test_run_all_models.py
@@ -65,7 +65,7 @@ def test_all_cam_models_can_run(numpy_image, batch_size, width, height,
 
     cam = cam_method(model=model,
                      target_layers=target_layers,
-                     use_cuda=False)
+                     device=None)
     cam.batch_size = 4
     if target_category is None:
         targets = None


### PR DESCRIPTION
Instead of using the boolean parameter `use_cuda`, we take a parameter of type `torch.device`. This can be `cuda` but it can also be `torch.device("mps")` for example. This adds support for GPU Acceleration on Apple Silicon.

I ran all the tests switching the device to `mps`, and they all passed. 

For now i have only edited the code. Documentation and tutorials still have the current content.