### PR TITLE
Address cv2.resize float16 issue in scale_cam_image

### DIFF
--- a/pytorch_grad_cam/utils/image.py
+++ b/pytorch_grad_cam/utils/image.py
@@ -163,7 +163,7 @@ def scale_cam_image(cam, target_size=None):
         img = img - np.min(img)
         img = img / (1e-7 + np.max(img))
         if target_size is not None:
-            img = cv2.resize(img, target_size)
+            img = cv2.resize(np.float32(img), target_size)
         result.append(img)
     result = np.float32(result)
 


### PR DESCRIPTION
https://github.com/jacobgil/pytorch-grad-cam/issues/198
https://github.com/jacobgil/pytorch-grad-cam/issues/493

Putting in a PR to go along with my issue post.

cv2.resize doesn't support float16 which causes this step to break. This fixes the issue with not downstream consequences that I can identify since the resulting image gets converted to lfoat32 anyways.