### PR TITLE
Fix use_cuda of swin transformer example code

### DIFF
--- a/usage_examples/swinT_example.py
+++ b/usage_examples/swinT_example.py
@@ -97,13 +97,11 @@ if __name__ == '__main__':
     if args.method == "ablationcam":
         cam = methods[args.method](model=model,
                                    target_layers=target_layers,
-                                   use_cuda=args.use_cuda,
                                    reshape_transform=reshape_transform,
                                    ablation_layer=AblationLayerVit())
     else:
         cam = methods[args.method](model=model,
                                    target_layers=target_layers,
-                                   use_cuda=args.use_cuda,
                                    reshape_transform=reshape_transform)
 
     rgb_img = cv2.imread(args.image_path, 1)[:, :, ::-1]


### PR DESCRIPTION
Based on https://github.com/jacobgil/pytorch-grad-cam/issues/504, `use_cuda` already removed in https://github.com/jacobgil/pytorch-grad-cam/commit/00711a20b7a8dfb6d6d1d892216997daeeee6288, so user will get error when executing swin transformer example code currently.

After fixing, the code will run successfully for CPU and GPU scenario, following is my test result:
```
$ python3 usage_examples/swinT_example.py --use-cuda
Using GPU for acceleration
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 32/32 [00:07<00:00,  4.43it/s]

$ python3 usage_examples/swinT_example.py
Using CPU for computation
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 32/32 [02:01<00:00,  3.78s/it]

```