### PR TITLE
Fix CUDA memory leak in ShapleyCAM by explicitly breaking the autograd graph

### DIFF
--- a/pytorch_grad_cam/activations_and_gradients.py
+++ b/pytorch_grad_cam/activations_and_gradients.py
@@ -1,3 +1,4 @@
+import torch
 class ActivationsAndGradients:
     """ Class for extracting activations and
     registering gradients from targetted intermediate layers """
@@ -47,6 +48,20 @@ class ActivationsAndGradients:
         self.activations = []
         return self.model(x)
 
+    def clear(self):
+        # Explicitly detach tensors from the autograd graph
+        for a in self.activations:
+            if isinstance(a, torch.Tensor):
+                a.detach_()
+        for g in self.gradients:
+            if isinstance(g, torch.Tensor):
+                g.detach_()
+    
+        self.activations.clear()
+        self.gradients.clear()
+
     def release(self):
+        self.clear()
         for handle in self.handles:
             handle.remove()
+        self.handles.clear()

--- a/tests/test_context_release_cuda.py
+++ b/tests/test_context_release_cuda.py
@@ -3,6 +3,8 @@ import torchvision
 import torch
 import cv2
 import psutil
+import pytorch_grad_cam
+print("pytorch_grad_cam loaded from:", pytorch_grad_cam.__file__)
 from pytorch_grad_cam import GradCAM, \
     ScoreCAM, \
     GradCAMPlusPlus, \
@@ -46,10 +48,14 @@ def numpy_image():
 def test_memory_usage_in_loop(numpy_image, batch_size, width, height,
                               cnn_model, target_layer_names, cam_method,
                               target_category, aug_smooth, eigen_smooth):
+    if torch.cuda.is_available():
+        device = "cuda"
+    else:
+        device = "cpu"
     img = cv2.resize(numpy_image, (width, height))
     input_tensor = preprocess_image(img)
-    input_tensor = input_tensor.repeat(batch_size, 1, 1, 1)
-    model = cnn_model(pretrained=True)
+    input_tensor = input_tensor.repeat(batch_size, 1, 1, 1).to(device)
+    model = cnn_model(pretrained=True).to(device)
     target_layers = []
     for layer in target_layer_names:
         target_layers.append(eval(f"model.{layer}"))
@@ -65,5 +71,5 @@ def test_memory_usage_in_loop(numpy_image, batch_size, width, height,
                                 eigen_smooth=eigen_smooth)
 
             if i == 0:
-                initial_memory = psutil.virtual_memory()[2]
-        assert(psutil.virtual_memory()[2] <= initial_memory * 1.5)
+                initial_memory = torch.cuda.memory_allocated()
+        assert(torch.cuda.memory_allocated() <= initial_memory * 1.5)

--- a/tests/test_context_release_cuda.py
+++ b/tests/test_context_release_cuda.py
@@ -51,7 +51,8 @@ def test_memory_usage_in_loop(numpy_image, batch_size, width, height,
     if torch.cuda.is_available():
         device = "cuda"
     else:
-        device = "cpu"
+        print("CUDA not available")
+        return
     img = cv2.resize(numpy_image, (width, height))
     input_tensor = preprocess_image(img)
     input_tensor = input_tensor.repeat(batch_size, 1, 1, 1).to(device)


### PR DESCRIPTION
## Description

This PR fixes a GPU memory leak observed when running **ShapleyCAM** on CUDA devices with higher-order gradient computation enabled.

### Background

Initially, `ShapleyCAM` was added to `tests/test_context_release.py`, and it successfully passed the existing tests.  
However, after reviewing the test logic, it became clear that the current coverage only checks for **CPU memory usage** and does not account for **GPU memory behavior**.

To address this gap, a new CUDA-specific test (`test_context_release_cuda.py`) was introduced to explicitly verify GPU memory usage during repeated forward passes.  
This test revealed that the original implementation indeed caused a **CUDA memory leak** when using `ShapleyCAM`.

### Root Cause

`ShapleyCAM` relies on higher-order gradients (Hessian-vector products), which require `torch.autograd.grad(..., create_graph=True)`.  
When `detach=False`, intermediate activations and gradients stored inside `ActivationsAndGradients` retained references to the autograd graph.

Although forward/backward hooks were properly removed, the autograd computation graph itself was never explicitly broken.  
As a result, the graph was unintentionally kept alive across iterations, leading to steadily increasing GPU memory usage.

### What’s changed

- Explicitly detach activation and gradient tensors after CAM computation.
- Clear stored activations and gradients to break references to the autograd graph.
- Add a CUDA-specific regression test to validate correct GPU memory behavior.

### Test Results

**Before the fix**

```bash
FAILED tests/test_context_release_cuda.py::test_memory_usage_in_loop[ShapleyCAM-False-False-100-1-224-224-resnet18-target_layer_names0]
AssertionError: assert 153555968 <= (88220672 * 1.5)

1 failed, 1 passed, 4 warnings in 3.37s
```


**After the fix**

```bash
2 passed, 4 warnings in 3.40s
```


### Impact

- Fixes a real GPU memory leak when using `ShapleyCAM` on CUDA devices.
- Improves test coverage by explicitly validating CUDA memory behavior.
