### PR TITLE
Fix matplotlib >= 3.8 AttributeError in show_factorization_on_image

### DIFF
--- a/pytorch_grad_cam/utils/image.py
+++ b/pytorch_grad_cam/utils/image.py
@@ -151,9 +151,8 @@ def show_factorization_on_image(img: np.ndarray,
         plt.tight_layout(pad=0, w_pad=0, h_pad=0)
         plt.axis('off')
         fig.canvas.draw()
-        data = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
+        data = np.asarray(fig.canvas.buffer_rgba())[..., :3].copy()
         plt.close(fig=fig)
-        data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,))
         data = cv2.resize(data, (result.shape[1], result.shape[0]))
         result = np.hstack((result, data))
     return result


### PR DESCRIPTION
## Problem

`show_factorization_on_image` raises an `AttributeError` with matplotlib >= 3.8:

```
AttributeError: 'FigureCanvasAgg' object has no attribute 'tostring_rgb'
```

`FigureCanvasAgg.tostring_rgb()` was [deprecated in matplotlib 3.8](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.8.0.html) and removed in 3.10.

## Fix

Replace `tostring_rgb()` with `buffer_rgba()`, which is the recommended successor:

```python
# Before
data = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
plt.close(fig=fig)
data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,))

# After
data = np.asarray(fig.canvas.buffer_rgba())[..., :3].copy()
plt.close(fig=fig)
```

### Why this works

| | `tostring_rgb()` (old) | `buffer_rgba()` (new) |
|---|---|---|
| **Return type** | flat `bytes` | shaped `memoryview` (H × W × 4) |
| **Channels** | RGB (3) | RGBA (4) |
| **Reshape needed** | yes (`frombuffer` + `reshape`) | no (already H × W × 4) |

Since `buffer_rgba()` returns a properly shaped RGBA array, we:
1. Slice off the alpha channel with `[..., :3]` to get RGB
2. Call `.copy()` to detach from the canvas buffer before `plt.close()` frees it
3. Drop the now-unnecessary `reshape` call

### Backward compatibility

`buffer_rgba()` has been available since matplotlib 3.1, so this change is backward-compatible with any matplotlib version that this library reasonably supports.

Fixes #556