### PR TITLE
Fix NoneType crash when model.eval() does not return self

### DIFF
--- a/pytorch_grad_cam/base_cam.py
+++ b/pytorch_grad_cam/base_cam.py
@@ -21,7 +21,8 @@ class BaseCAM:
         tta_transforms: Optional[tta.Compose] = None,
         detach: bool = True,
     ) -> None:
-        self.model = model.eval()
+        self.model = model
+        self.model.eval()
         self.target_layers = target_layers
 
         # Use the same device as the model.


### PR DESCRIPTION
## Problem

Passing a model whose `.eval()` does not return `self` causes an immediate crash in `BaseCAM.__init__`:

```
  File "pytorch_grad_cam/base_cam.py", line 28, in __init__
    self.device = next(self.model.parameters()).device
                       ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'parameters'
```

### Root cause

```python
self.model = model.eval()  # None if eval() doesn't return self
```

Standard `nn.Module.eval()` returns `self`, but some third-party wrappers (quantization toolkits, custom tracing wrappers) override `.eval()` without propagating the return value — making `model.eval()` return `None`.

## Fix

Separate assignment from the `.eval()` call:

```python
self.model = model
self.model.eval()
```

This guarantees `self.model` always holds the model reference, regardless of what `.eval()` returns.

### Precedent in this codebase

`guided_backprop.py` already uses the safe pattern:

```python
# guided_backprop.py, line 49
self.model.eval()
```

This PR aligns `base_cam.py` with that existing convention.

Fixes #569