### PR TITLE
Add scipy to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tqdm
 opencv-python
 matplotlib
 scikit-learn
+scipy


### PR DESCRIPTION
`scipy` has been imported by the library since #466 (`from scipy.ndimage import zoom` in `pytorch_grad_cam/utils/image.py`) and `pytorch_grad_cam/metrics/road.py` pulls in `scipy.sparse`, but `requirements.txt` doesn't list it. A clean `pip install -r requirements.txt` followed by any 3-D CAM path or ROAD metric call raises `ModuleNotFoundError: No module named 'scipy'`.

`setup.py` reads `requirements.txt`, so adding one line there propagates to `install_requires`.