### PR TITLE
Make FasterRCNNBoxScoreTarget device-agnostic

### DIFF
--- a/pytorch_grad_cam/utils/model_targets.py
+++ b/pytorch_grad_cam/utils/model_targets.py
@@ -97,21 +97,14 @@ class FasterRCNNBoxScoreTarget:
         self.iou_threshold = iou_threshold
 
     def __call__(self, model_outputs):
-        output = torch.Tensor([0])
-        if torch.cuda.is_available():
-            output = output.cuda()
-        elif torch.backends.mps.is_available():
-            output = output.to("mps")
+        device = model_outputs["boxes"].device
+        output = torch.tensor([0.0], device=device)
 
         if len(model_outputs["boxes"]) == 0:
             return output
 
         for box, label in zip(self.bounding_boxes, self.labels):
-            box = torch.Tensor(box[None, :])
-            if torch.cuda.is_available():
-                box = box.cuda()
-            elif torch.backends.mps.is_available():
-                box = box.to("mps")
+            box = torch.as_tensor(box[None, :], device=device)
 
             ious = torchvision.ops.box_iou(box, model_outputs["boxes"])
             index = ious.argmax()

--- a/pytorch_grad_cam/utils/model_targets.py
+++ b/pytorch_grad_cam/utils/model_targets.py
@@ -97,16 +97,17 @@ class FasterRCNNBoxScoreTarget:
         self.iou_threshold = iou_threshold
 
     def __call__(self, model_outputs):
-        device = model_outputs["boxes"].device
-        output = torch.tensor([0.0], device=device)
+        boxes = model_outputs["boxes"]
+        device, dtype = boxes.device, boxes.dtype
+        output = torch.tensor([0.0], device=device, dtype=dtype)
 
-        if len(model_outputs["boxes"]) == 0:
+        if len(boxes) == 0:
             return output
 
         for box, label in zip(self.bounding_boxes, self.labels):
-            box = torch.as_tensor(box[None, :], device=device)
+            box = torch.as_tensor(box[None, :], device=device, dtype=dtype)
 
-            ious = torchvision.ops.box_iou(box, model_outputs["boxes"])
+            ious = torchvision.ops.box_iou(box, boxes)
             index = ious.argmax()
             if ious[0, index] > self.iou_threshold and model_outputs["labels"][index] == label:
                 score = ious[0, index] + model_outputs["scores"][index]

--- a/tests/test_fasterrcnn_target_device.py
+++ b/tests/test_fasterrcnn_target_device.py
@@ -34,3 +34,19 @@ def test_target_returns_zero_on_empty_boxes():
     score = target(outputs)
     assert score.device.type == "cpu"
     assert score.item() == 0.0
+
+
+def test_target_preserves_boxes_dtype():
+    """box_iou requires both inputs to share dtype; the target must not
+    silently upcast/downcast relative to model_outputs['boxes']."""
+    target = FasterRCNNBoxScoreTarget(
+        labels=[1],
+        bounding_boxes=[np.array([0.0, 0.0, 10.0, 10.0], dtype=np.float64)],
+    )
+    outputs = {
+        "boxes": torch.tensor([[0.0, 0.0, 10.0, 10.0]], dtype=torch.float64),
+        "labels": torch.tensor([1]),
+        "scores": torch.tensor([0.9], dtype=torch.float64),
+    }
+    score = target(outputs)
+    assert score.dtype == torch.float64

--- a/tests/test_fasterrcnn_target_device.py
+++ b/tests/test_fasterrcnn_target_device.py
@@ -1,0 +1,36 @@
+"""Regression test: FasterRCNNBoxScoreTarget must not hardcode cuda/mps.
+
+Mirrors the fix for SemanticSegmentationTarget (#546). The target must
+inherit the device of the model outputs instead of assuming cuda/mps.
+"""
+import numpy as np
+import torch
+
+from pytorch_grad_cam.utils.model_targets import FasterRCNNBoxScoreTarget
+
+
+def test_target_inherits_output_device_cpu():
+    target = FasterRCNNBoxScoreTarget(
+        labels=[1],
+        bounding_boxes=[np.array([0.0, 0.0, 10.0, 10.0], dtype=np.float32)],
+    )
+    outputs = {
+        "boxes": torch.tensor([[0.0, 0.0, 10.0, 10.0]], device="cpu"),
+        "labels": torch.tensor([1], device="cpu"),
+        "scores": torch.tensor([0.9], device="cpu"),
+    }
+    score = target(outputs)
+    assert score.device.type == "cpu"
+    assert score.item() > 0
+
+
+def test_target_returns_zero_on_empty_boxes():
+    target = FasterRCNNBoxScoreTarget(labels=[1], bounding_boxes=[np.zeros(4)])
+    outputs = {
+        "boxes": torch.zeros((0, 4), device="cpu"),
+        "labels": torch.zeros((0,), dtype=torch.int64, device="cpu"),
+        "scores": torch.zeros((0,), device="cpu"),
+    }
+    score = target(outputs)
+    assert score.device.type == "cpu"
+    assert score.item() == 0.0


### PR DESCRIPTION
Mirrors the fix #546 applied to `SemanticSegmentationTarget`. `FasterRCNNBoxScoreTarget` still hard-codes

```python
if torch.cuda.is_available():
    output = output.cuda()
elif torch.backends.mps.is_available():
    output = output.to(\"mps\")
```

twice inside `__call__`, which forces CUDA/MPS even when the user explicitly pins the detection model to CPU (or to an accelerator that doesn't match the `cuda/mps` whitelist, e.g. HPU added in #547). The fix is the same pattern as #546 — take the device from `model_outputs[\"boxes\"].device` and construct both the running scalar and the per-iteration `box` tensor on it.

Regression test: `tests/test_fasterrcnn_target_device.py` pins the target to CPU and checks the returned score stays on CPU (plus an empty-boxes early-return case).