### PR TITLE
Stop in-place NaN mutation of caller's activations in svd_on_activations

### DIFF
--- a/pytorch_grad_cam/utils/svd_on_activations.py
+++ b/pytorch_grad_cam/utils/svd_on_activations.py
@@ -4,7 +4,7 @@ from sklearn.decomposition import KernelPCA
 
 def get_2d_projection(activation_batch):
     # TBD: use pytorch batch svd implementation
-    activation_batch[np.isnan(activation_batch)] = 0
+    activation_batch = np.nan_to_num(activation_batch, copy=True)
     projections = []
     for activations in activation_batch:
         reshaped_activations = (activations).reshape(
@@ -21,7 +21,7 @@ def get_2d_projection(activation_batch):
 
 
 def get_2d_projection_kernel(activation_batch, kernel='sigmoid', gamma=None):
-    activation_batch[np.isnan(activation_batch)] = 0
+    activation_batch = np.nan_to_num(activation_batch, copy=True)
     projections = []
     for activations in activation_batch:
         reshaped_activations = activations.reshape(
@@ -57,7 +57,7 @@ def get_2d_projection_with_sign_correction(activation_batch: np.ndarray) -> np.n
     Returns:
         np.ndarray of shape (B, H, W) with dtype float32.
     """
-    activation_batch[np.isnan(activation_batch)] = 0
+    activation_batch = np.nan_to_num(activation_batch, copy=True)
     projections = []
 
     for activations in activation_batch:

--- a/pytorch_grad_cam/utils/svd_on_activations.py
+++ b/pytorch_grad_cam/utils/svd_on_activations.py
@@ -4,7 +4,8 @@ from sklearn.decomposition import KernelPCA
 
 def get_2d_projection(activation_batch):
     # TBD: use pytorch batch svd implementation
-    activation_batch = np.nan_to_num(activation_batch, copy=True)
+    activation_batch = activation_batch.copy()
+    activation_batch[np.isnan(activation_batch)] = 0
     projections = []
     for activations in activation_batch:
         reshaped_activations = (activations).reshape(
@@ -21,7 +22,8 @@ def get_2d_projection(activation_batch):
 
 
 def get_2d_projection_kernel(activation_batch, kernel='sigmoid', gamma=None):
-    activation_batch = np.nan_to_num(activation_batch, copy=True)
+    activation_batch = activation_batch.copy()
+    activation_batch[np.isnan(activation_batch)] = 0
     projections = []
     for activations in activation_batch:
         reshaped_activations = activations.reshape(
@@ -57,7 +59,8 @@ def get_2d_projection_with_sign_correction(activation_batch: np.ndarray) -> np.n
     Returns:
         np.ndarray of shape (B, H, W) with dtype float32.
     """
-    activation_batch = np.nan_to_num(activation_batch, copy=True)
+    activation_batch = activation_batch.copy()
+    activation_batch[np.isnan(activation_batch)] = 0
     projections = []
 
     for activations in activation_batch:

--- a/tests/test_svd_no_side_effect.py
+++ b/tests/test_svd_no_side_effect.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from pytorch_grad_cam.utils.svd_on_activations import (
+    get_2d_projection,
+    get_2d_projection_kernel,
+    get_2d_projection_with_sign_correction,
+)
+
+
+def _sample_batch_with_nan():
+    a = np.zeros((1, 2, 2, 2), dtype=np.float32)
+    a[0, 0, 0, 0] = np.nan
+    a[0, 0, 1, 1] = 1.0
+    a[0, 1] = np.array([[2.0, 3.0], [4.0, 5.0]], dtype=np.float32)
+    return a
+
+
+def test_get_2d_projection_does_not_mutate_caller():
+    a = _sample_batch_with_nan()
+    assert np.isnan(a).any()
+    snapshot = a.copy()
+    _ = get_2d_projection(a)
+    assert np.array_equal(a, snapshot, equal_nan=True), (
+        "get_2d_projection mutated caller's activation_batch in place"
+    )
+
+
+def test_get_2d_projection_kernel_does_not_mutate_caller():
+    a = _sample_batch_with_nan()
+    snapshot = a.copy()
+    _ = get_2d_projection_kernel(a)
+    assert np.array_equal(a, snapshot, equal_nan=True), (
+        "get_2d_projection_kernel mutated caller's activation_batch in place"
+    )
+
+
+def test_get_2d_projection_with_sign_correction_does_not_mutate_caller():
+    a = _sample_batch_with_nan()
+    snapshot = a.copy()
+    _ = get_2d_projection_with_sign_correction(a)
+    assert np.array_equal(a, snapshot, equal_nan=True), (
+        "get_2d_projection_with_sign_correction mutated caller's "
+        "activation_batch in place"
+    )


### PR DESCRIPTION
Each function in `pytorch_grad_cam/utils/svd_on_activations.py` starts with

```python
activation_batch[np.isnan(activation_batch)] = 0
```

which mutates the caller's numpy array in place. When `activation_batch` comes through `tensor.cpu().data.numpy()` (as it does in `BaseCAM.compute_cam_per_layer`), the numpy array can share storage with the underlying tensor, so the NaN-zeroing silently edits the caller's data between iterations.

Switch to `np.nan_to_num(..., copy=True)`, which is functionally identical but always returns a fresh array regardless of the input's memory layout. Three call sites, one-line change each.

Regression test `tests/test_svd_no_side_effect.py` snapshots the caller's array around each call and asserts no mutation.