### PR TITLE
FinerCAM: context-manager support, clamp to num_classes, fix HPU attribute mangling

### DIFF
--- a/pytorch_grad_cam/base_cam.py
+++ b/pytorch_grad_cam/base_cam.py
@@ -32,7 +32,7 @@ class BaseCAM:
             except ImportError as error:
                 error.msg = f"Could not import habana_frameworks.torch.core. {error.msg}."
                 raise error
-            self.__htcore = htcore
+            self._htcore = htcore
         self.reshape_transform = reshape_transform
         self.compute_input_gradient = compute_input_gradient
         self.uses_gradients = uses_gradients
@@ -115,7 +115,7 @@ class BaseCAM:
                 # When using the following loss.backward() method, a warning is raised: "UserWarning: Using backward() with create_graph=True will create a reference cycle"
                 # loss.backward(retain_graph=True, create_graph=True)
             if 'hpu' in str(self.device):
-                self.__htcore.mark_step()
+                self._htcore.mark_step()
 
         # In most of the saliency attribution papers, the saliency is
         # computed with a single target layer.

--- a/pytorch_grad_cam/finer_cam.py
+++ b/pytorch_grad_cam/finer_cam.py
@@ -1,12 +1,22 @@
 import numpy as np
 import torch
-from typing import List, Callable
+from typing import Callable, List, Optional
 from pytorch_grad_cam.base_cam import BaseCAM
 from pytorch_grad_cam import GradCAM
 from pytorch_grad_cam.utils.model_targets import FinerWeightedTarget
 
+
+DEFAULT_COMPARISON_CATEGORIES = (1, 2, 3)
+
+
 class FinerCAM:
-    def __init__(self, model: torch.nn.Module, target_layers: List[torch.nn.Module], reshape_transform: Callable = None, base_method=GradCAM):
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        target_layers: List[torch.nn.Module],
+        reshape_transform: Callable = None,
+        base_method=GradCAM,
+    ):
         self.base_cam = base_method(model, target_layers, reshape_transform)
         self.compute_input_gradient = self.base_cam.compute_input_gradient
         self.uses_gradients = self.base_cam.uses_gradients
@@ -14,9 +24,35 @@ class FinerCAM:
     def __call__(self, *args, **kwargs):
         return self.forward(*args, **kwargs)
 
-    def forward(self, input_tensor: torch.Tensor, targets: List[torch.nn.Module] = None, eigen_smooth: bool = False,
-                alpha: float = 1, comparison_categories: List[int] = [1, 2, 3], target_idx: int = None
-                ) -> np.ndarray:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        # Delegate teardown to the underlying CAM so forward hooks are released
+        # when users wrap FinerCAM in a `with` statement, mirroring BaseCAM.
+        self.base_cam.activations_and_grads.release()
+        if isinstance(exc_value, IndexError):
+            print(
+                f"An exception occurred in CAM with block: {exc_type}. "
+                f"Message: {exc_value}"
+            )
+            return True
+
+    def __del__(self):
+        try:
+            self.base_cam.activations_and_grads.release()
+        except Exception:
+            pass
+
+    def forward(
+        self,
+        input_tensor: torch.Tensor,
+        targets: List[torch.nn.Module] = None,
+        eigen_smooth: bool = False,
+        alpha: float = 1,
+        comparison_categories: Optional[List[int]] = None,
+        target_idx: int = None,
+    ) -> np.ndarray:
         input_tensor = input_tensor.to(self.base_cam.device)
 
         if self.compute_input_gradient:
@@ -26,28 +62,55 @@ class FinerCAM:
 
         if targets is None:
             output_data = outputs.detach().cpu().numpy()
-            target_logits = np.max(output_data, axis=-1) if target_idx is None else output_data[:, target_idx]
-            # Sort class indices for each sample based on the absolute difference 
+            num_classes = output_data.shape[-1]
+
+            # Default the comparison slice to [1, 2, 3] but clamp to the number of
+            # available sorted-by-similarity classes so binary / ternary models
+            # don't IndexError. Using a tuple constant avoids the mutable-default
+            # argument anti-pattern.
+            if comparison_categories is None:
+                max_comparisons = max(num_classes - 1, 0)
+                comparison_categories = list(DEFAULT_COMPARISON_CATEGORIES[:max_comparisons])
+            else:
+                comparison_categories = [c for c in comparison_categories if c < num_classes]
+
+            target_logits = (
+                np.max(output_data, axis=-1)
+                if target_idx is None
+                else output_data[:, target_idx]
+            )
+            # Sort class indices for each sample based on the absolute difference
             # between the class scores and the target logit, in ascending order.
             # The most similar classes (smallest difference) appear first.
-            sorted_indices = np.argsort(np.abs(output_data - target_logits[:, None]), axis=-1)
-            targets = [FinerWeightedTarget(int(sorted_indices[i, 0]), 
-                                           [int(sorted_indices[i, idx]) for idx in comparison_categories], 
-                                           alpha) 
-                       for i in range(output_data.shape[0])]
+            sorted_indices = np.argsort(
+                np.abs(output_data - target_logits[:, None]), axis=-1
+            )
+            targets = [
+                FinerWeightedTarget(
+                    int(sorted_indices[i, 0]),
+                    [int(sorted_indices[i, idx]) for idx in comparison_categories],
+                    alpha,
+                )
+                for i in range(output_data.shape[0])
+            ]
 
         if self.uses_gradients:
             self.base_cam.model.zero_grad()
-            loss = sum([target(output) for target, output in zip(targets, outputs)])
+            loss = sum(target(output) for target, output in zip(targets, outputs))
             if self.base_cam.detach:
                 loss.backward(retain_graph=True)
             else:
-                # keep the computational graph, create_graph = True is needed for hvp
-                torch.autograd.grad(loss, input_tensor, retain_graph = True, create_graph = True)
-                # When using the following loss.backward() method, a warning is raised: "UserWarning: Using backward() with create_graph=True will create a reference cycle"
-                # loss.backward(retain_graph=True, create_graph=True)
-            if 'hpu' in str(self.base_cam.device):
-                self.base_cam.__htcore.mark_step()
+                # keep the computational graph, create_graph=True is needed for hvp
+                torch.autograd.grad(
+                    loss, input_tensor, retain_graph=True, create_graph=True
+                )
+            if "hpu" in str(self.base_cam.device):
+                # Access the underscore-prefixed attribute directly; the previous
+                # double-underscore access triggered Python name mangling to
+                # `_FinerCAM__htcore` and would AttributeError on HPU.
+                self.base_cam._htcore.mark_step()
 
-        cam_per_layer = self.base_cam.compute_cam_per_layer(input_tensor, targets, eigen_smooth)
+        cam_per_layer = self.base_cam.compute_cam_per_layer(
+            input_tensor, targets, eigen_smooth
+        )
         return self.base_cam.aggregate_multi_layers(cam_per_layer)

--- a/tests/test_finer_cam_correctness.py
+++ b/tests/test_finer_cam_correctness.py
@@ -1,0 +1,61 @@
+"""Regression tests for FinerCAM:
+
+1. Supports the `with FinerCAM(...) as cam:` protocol used by cam.py (K3).
+2. Does not IndexError on models with fewer than 4 output classes (K8).
+3. References self.base_cam._htcore (single underscore) so name-mangling does
+   not break HPU users (K10 — static check since no HPU hardware in CI).
+"""
+
+import inspect
+
+import torch
+import torch.nn as nn
+
+from pytorch_grad_cam import FinerCAM
+
+
+def _cnn(num_classes: int) -> nn.Module:
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(3, 4, 3, padding=1)
+            self.pool = nn.AdaptiveAvgPool2d(1)
+            self.fc = nn.Linear(4, num_classes)
+
+        def forward(self, x):
+            return self.fc(self.pool(torch.relu(self.conv(x))).flatten(1))
+
+    m = M()
+    m.eval()
+    return m
+
+
+def test_finercam_supports_context_manager():
+    model = _cnn(10)
+    with FinerCAM(model=model, target_layers=[model.conv]) as cam:
+        assert cam is not None
+
+
+def test_finercam_runs_on_binary_classifier_without_index_error():
+    model = _cnn(2)
+    x = torch.randn(1, 3, 16, 16)
+    with FinerCAM(model=model, target_layers=[model.conv]) as cam:
+        out = cam(input_tensor=x, targets=None)
+    assert out.shape == (1, 16, 16)
+
+
+def test_finercam_runs_on_ternary_classifier_without_index_error():
+    model = _cnn(3)
+    x = torch.randn(1, 3, 16, 16)
+    with FinerCAM(model=model, target_layers=[model.conv]) as cam:
+        out = cam(input_tensor=x, targets=None)
+    assert out.shape == (1, 16, 16)
+
+
+def test_finercam_htcore_is_single_underscore():
+    """Guard against re-introducing the name-mangled `__htcore` attribute."""
+    src = inspect.getsource(FinerCAM)
+    assert "self.base_cam.__htcore" not in src, (
+        "FinerCAM must not reference self.base_cam.__htcore (name-mangled)"
+    )
+    assert "self.base_cam._htcore" in src, "FinerCAM should call into _htcore"


### PR DESCRIPTION
Three related defects in `pytorch_grad_cam/finer_cam.py`, rolled into one PR because they all touch the same module:

1. **Context-manager protocol.** `cam.py:123` wraps every method in `with cam_algorithm(...) as cam:`. `FinerCAM` isn't a `BaseCAM` subclass and never defined `__enter__` / `__exit__`, so `python cam.py --method finercam ...` raises `TypeError: 'FinerCAM' object does not support the context manager protocol`. Added an explicit context-manager protocol that forwards to `self.base_cam.activations_and_grads.release()` on exit, matching `BaseCAM.__exit__` semantics.

2. **`IndexError` on small classifiers.** `forward()` had `comparison_categories: List[int] = [1, 2, 3]` as a mutable default, and the `sorted_indices[i, idx]` indexing crashes on 2- or 3-class models:

   ```
   IndexError: index 2 is out of bounds for axis 1 with size 2
   ```

   Default is now `None`; inside the function we clamp to `range(1, num_classes)` so binary / ternary / fine-grained few-class tasks still work.

3. **HPU name-mangling.** `self.base_cam.__htcore.mark_step()` inside `FinerCAM` is mangled by Python to `self.base_cam._FinerCAM__htcore`, which doesn't exist on `BaseCAM` (it stored it as `_BaseCAM__htcore`). Any Gaudi user reaching this path via #547 hits `AttributeError`. Renamed `BaseCAM.__htcore` → `BaseCAM._htcore` (single underscore) and updated the two references in `base_cam.py` and the one in `finer_cam.py`.

Regression tests in `tests/test_finer_cam_correctness.py`:
- `with FinerCAM(...) as cam:` succeeds
- binary-class CNN + FinerCAM no longer `IndexError`s
- ternary-class CNN + FinerCAM no longer `IndexError`s
- source-level guard ensuring `__htcore` never reappears (can't test HPU without hardware).