### PR TITLE
Migrate pretrained=True to weights=<Weights>.DEFAULT (torchvision ≥0.13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ The aim is also to serve as a benchmark of algorithms and metrics for research o
 from pytorch_grad_cam import GradCAM, HiResCAM, ScoreCAM, GradCAMPlusPlus, AblationCAM, XGradCAM, EigenCAM, FullGrad
 from pytorch_grad_cam.utils.model_targets import ClassifierOutputTarget
 from pytorch_grad_cam.utils.image import show_cam_on_image
-from torchvision.models import resnet50
+from torchvision.models import resnet50, ResNet50_Weights
 
-model = resnet50(pretrained=True)
+model = resnet50(weights=ResNet50_Weights.DEFAULT)
 target_layers = [model.layer4[-1]]
 input_tensor = # Create an input tensor image for your model..
 # Note: input_tensor can be a batch tensor with several images!

--- a/cam.py
+++ b/cam.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
     if args.device=='hpu':
         import habana_frameworks.torch.core as htcore
 
-    model = models.resnet50(pretrained=True).to(torch.device(args.device)).eval()
+    model = models.resnet50(weights=models.ResNet50_Weights.DEFAULT).to(torch.device(args.device)).eval()
 
     # Choose the target layer you want to compute the visualization for.
     # Usually this will be the last convolutional layer in the model.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 Pillow
 torch>=1.7.1
-torchvision>=0.8.2
+torchvision>=0.13
 ttach
 tqdm
 opencv-python

--- a/tests/test_context_release.py
+++ b/tests/test_context_release.py
@@ -48,7 +48,7 @@ def test_memory_usage_in_loop(numpy_image, batch_size, width, height,
     img = cv2.resize(numpy_image, (width, height))
     input_tensor = preprocess_image(img)
     input_tensor = input_tensor.repeat(batch_size, 1, 1, 1)
-    model = cnn_model(pretrained=True)
+    model = cnn_model(weights="DEFAULT")
     target_layers = []
     for layer in target_layer_names:
         target_layers.append(eval(f"model.{layer}"))

--- a/tests/test_run_all_models.py
+++ b/tests/test_run_all_models.py
@@ -63,7 +63,7 @@ def test_all_cam_models_can_run(numpy_image, batch_size, width, height,
     input_tensor = preprocess_image(img)
     input_tensor = input_tensor.repeat(batch_size, 1, 1, 1)
 
-    model = cnn_model(pretrained=True)
+    model = cnn_model(weights="DEFAULT")
     target_layers = []
     for layer in target_layer_names:
         target_layers.append(eval(f"model.{layer}"))


### PR DESCRIPTION
`torchvision` deprecated `pretrained=True` in 0.13 (mid-2022) and will remove it in a future release. On modern torchvision each call already emits `FutureWarning`, and CI will start failing once the kwarg is gone.

Changes:

- `cam.py`: `models.resnet50(pretrained=True)` → `models.resnet50(weights=models.ResNet50_Weights.DEFAULT)`
- `tests/test_run_all_models.py`, `tests/test_context_release.py`: `cnn_model` is a pytest-parametrized factory (resnet18 / vgg11 here), so the portable form `cnn_model(weights=\"DEFAULT\")` is what's shipping here — works for any `torchvision.models` factory.
- `README.md`: update the quick-start snippet and import `ResNet50_Weights`.
- `requirements.txt`: bump `torchvision>=0.13` to reflect the new API.

Intentionally **not** touched:

- `usage_examples/vit_example.py`, `usage_examples/swinT_example.py` — these call `timm.create_model(..., pretrained=True)`. That is `timm`'s own API, unrelated to torchvision's deprecation.
- Tutorial notebooks — the notebook source would re-render huge diffs and there's no CI gate on them; happy to follow up in a separate PR if you'd prefer.