### PR TITLE
fix: use NotImplementedError instead of generic Exception

### DIFF
--- a/pytorch_grad_cam/base_cam.py
+++ b/pytorch_grad_cam/base_cam.py
@@ -62,7 +62,7 @@ class BaseCAM:
         activations: torch.Tensor,
         grads: torch.Tensor,
     ) -> np.ndarray:
-        raise Exception("Not Implemented")
+        raise NotImplementedError("get_cam_weights must be implemented by subclass")
 
     def get_cam_image(
         self,


### PR DESCRIPTION
Replace raise Exception with NotImplementedError in get_cam_weights()